### PR TITLE
Zombie move/shoot base

### DIFF
--- a/Assets/Scenes/Kiara_Sandbox.unity
+++ b/Assets/Scenes/Kiara_Sandbox.unity
@@ -235,6 +235,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mouseDeadzone: 0.4
+  mouseSignalLimit: 2
   mouseLookDistance: {x: 2, y: 3}
   mouseLookSpeed: {x: 0.02, y: 0.02}
   mouseViewScaling: 0.07
@@ -250,26 +251,13 @@ GameObject:
   m_Component:
   - component: {fileID: 136244883}
   - component: {fileID: 136244882}
-  - component: {fileID: 136244881}
   m_Layer: 0
   m_Name: ZombieWithGun
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!114 &136244881
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 136244880}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7b349b4b90a70514fafb13521d08ff7b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_IsActive: 1
 --- !u!212 &136244882
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -309,7 +297,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_Sprite: {fileID: 7482667652216324306, guid: 04f9592dfebac3c4b952aedbabb8867e, type: 3}
   m_Color: {r: 0.129807, g: 0.28235295, b: 0.12936097, a: 1}
   m_FlipX: 0

--- a/Assets/Scripts/Zombie.meta
+++ b/Assets/Scripts/Zombie.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f88a98e72ab5cd4d9afa54808bfc0cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Zombie/ExampleShoot.cs
+++ b/Assets/Scripts/Zombie/ExampleShoot.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ExampleShoot : ZombieShootBase
+{
+    [SerializeField] private GameObject bullet;
+    [SerializeField] private float fireDelay = 2.0f;
+
+    private float timeLeft = 0;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        base.Start();
+
+        timeLeft = fireDelay;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (timeLeft <= 0 && !IsMoving())
+        {
+            timeLeft = fireDelay;
+            Shoot();
+        }
+        else
+        {
+            timeLeft -= Time.deltaTime;
+        }
+    }
+
+    public override bool IsShooting()
+    {
+        return false;
+    }
+
+    void Shoot()
+    {
+        Instantiate(bullet, transform.position, Quaternion.identity);
+    }
+}

--- a/Assets/Scripts/Zombie/ExampleShoot.cs.meta
+++ b/Assets/Scripts/Zombie/ExampleShoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d619614f54e76240a0fce3438c0d464
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Zombie/ZombieMovementBase.cs
+++ b/Assets/Scripts/Zombie/ZombieMovementBase.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+/// <summary>
+/// Derive your zombie movement behaviors from this.
+/// </summary>
+[RequireComponent(typeof(ZombieShootBase))]
+public abstract class ZombieMovementBase : MonoBehaviour
+{
+    ZombieShootBase shootBase;
+
+    /// <summary>
+    /// If you use Start() in your behavior, you MUST call base.Start()!!!!
+    /// </summary>
+    virtual protected void Start()
+    {
+        shootBase = GetComponent<ZombieShootBase>();
+    }
+
+
+    /// <summary>
+    /// You must implement this method.
+    /// </summary>
+    /// <returns>true if the zombie is currently moving, false otherwise.</returns>
+    abstract public bool IsMoving();
+
+    /// <summary>
+    /// This is provided by the shooting behavior.
+    /// </summary>
+    /// <returns>true if the zombie is shooting or setting up a shot, false otherwise.</returns>
+    protected bool IsShooting()
+    {
+        return shootBase.IsShooting();
+    }
+}

--- a/Assets/Scripts/Zombie/ZombieMovementBase.cs
+++ b/Assets/Scripts/Zombie/ZombieMovementBase.cs
@@ -6,10 +6,9 @@ using UnityEngine;
 /// <summary>
 /// Derive your zombie movement behaviors from this.
 /// </summary>
-[RequireComponent(typeof(ZombieShootBase))]
 public abstract class ZombieMovementBase : MonoBehaviour
 {
-    ZombieShootBase shootBase;
+    private ZombieShootBase shootBase;
 
     /// <summary>
     /// If you use Start() in your behavior, you MUST call base.Start()!!!!

--- a/Assets/Scripts/Zombie/ZombieMovementBase.cs
+++ b/Assets/Scripts/Zombie/ZombieMovementBase.cs
@@ -17,6 +17,11 @@ public abstract class ZombieMovementBase : MonoBehaviour
     virtual protected void Start()
     {
         shootBase = GetComponent<ZombieShootBase>();
+
+        if(!shootBase)
+        {
+            DebugUtils.CrashAndBurn("Shooting base of some kind is required on " + gameObject.name + "!!!!!");
+        }
     }
 
 

--- a/Assets/Scripts/Zombie/ZombieMovementBase.cs.meta
+++ b/Assets/Scripts/Zombie/ZombieMovementBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1dc1a9c4165f2754ea90f0032ad87ca6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Zombie/ZombieShootBase.cs
+++ b/Assets/Scripts/Zombie/ZombieShootBase.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class ZombieShootBase : MonoBehaviour
+{
+    ZombieMovementBase moveBase;
+
+    /// <summary>
+    /// If you use Start() in your behavior, you MUST call base.Start()!!!!
+    /// </summary>
+    virtual protected void Start()
+    {
+        moveBase = GetComponent<ZombieMovementBase>();
+
+        if(!moveBase)
+        {
+            DebugUtils.CrashAndBurn("Movement base of some kind is required on " + gameObject.name + "!!!!!");
+        }
+    }
+
+
+    /// <summary>
+    /// This is provided by the moving behavior.
+    /// 
+    /// </summary>
+    /// <returns>true if the zombie is currently moving, false otherwise.</returns>
+    protected bool IsMoving()
+    {
+        return moveBase.IsMoving();
+    }
+
+    /// <summary>
+    /// You must implement this method.
+    /// </summary>
+    /// <returns>true if the zombie is shooting or setting up a shot, false otherwise.</returns>
+    abstract public bool IsShooting();
+}

--- a/Assets/Scripts/Zombie/ZombieShootBase.cs
+++ b/Assets/Scripts/Zombie/ZombieShootBase.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public abstract class ZombieShootBase : MonoBehaviour
 {
-    ZombieMovementBase moveBase;
+    private ZombieMovementBase moveBase;
 
     /// <summary>
     /// If you use Start() in your behavior, you MUST call base.Start()!!!!

--- a/Assets/Scripts/Zombie/ZombieShootBase.cs.meta
+++ b/Assets/Scripts/Zombie/ZombieShootBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d7659e280a8c8348a0074592ede0ea0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This system is pretty straightforward, check the example. Simple instructions for use:

- Create new behavior script
- Change it to inherit from either `ZombieMovementBase` or `ZombieShootBase` (instead of `MonoBehavior`) as appropriate
- If you have `Start()`. the first line in your `Start()` method MUST be `base.Start()`. (No good way to enforce this unfortunately)
- Implement the required method (either `IsShooting()` or `IsMoving()`), and take advantage of the provided method (whichever one you didn't implement).
- If you need more granular data access than these functions, let me know and I can easily amend this. This should be sufficient for now though.